### PR TITLE
Add readme to quickquants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# QuickQuants 2: A Shiny project


### PR DESCRIPTION
The quickquants repo was missing a readme, this adds an empty one ib.